### PR TITLE
Add channel config to serial datasource

### DIFF
--- a/dashboard/plugins/uplot.widget.js
+++ b/dashboard/plugins/uplot.widget.js
@@ -31,6 +31,41 @@
             this.dataBuffer = [[], []]; // [timestamps, [series1, series2, ...]]
             this.maxPoints = 2000;
             this.lastRender = 0;
+            this.channelNames = [];
+            this.channelColors = [];
+            this.seriesMeta = [];
+            this._parseSeriesMeta();
+            this._updateMetaFromDatasource();
+        }
+
+        _parseSeriesMeta() {
+            this.seriesMeta = [];
+            const expr = String(this.settings.data || '');
+            const regex = /datasources\[\s*['"]([^'"]+)['"]\]\s*\[\s*['"]y(\d+)['"]\s*\]/g;
+            let m;
+            while ((m = regex.exec(expr))) {
+                this.seriesMeta.push({ ds: m[1], idx: parseInt(m[2], 10) });
+            }
+        }
+
+        _updateMetaFromDatasource() {
+            if (!this.seriesMeta.length) return;
+            const cache = {};
+            this.channelNames = [];
+            this.channelColors = [];
+            this.seriesMeta.forEach(meta => {
+                if (!cache[meta.ds]) {
+                    cache[meta.ds] = freeboard.getDatasourceSettings(meta.ds) || {};
+                }
+                const cfgs = cache[meta.ds].channels;
+                const cfg = Array.isArray(cfgs) ? cfgs[meta.idx - 1] || {} : {};
+                this.channelNames.push(cfg.name || `ch${meta.idx}`);
+                if (cfg.color) {
+                    this.channelColors.push(cfg.color);
+                } else {
+                    this.channelColors.push(undefined);
+                }
+            });
         }
 
         render(containerElement) {
@@ -42,8 +77,9 @@
             const resolvedSeries = series || [{ label: "Time" }];
             if (!series) {
                 for (let i = 0; i < this.seriesCount; i++) {
-                    const color = `hsl(${(i * 60) % 360}, 70%, 50%)`;
-                    resolvedSeries.push({ label: `Channel ${i + 1}`, stroke: color });
+                    const color = this.channelColors[i] || `hsl(${(i * 60) % 360}, 70%, 50%)`;
+                    const label = this.channelNames[i] || `Channel ${i + 1}`;
+                    resolvedSeries.push({ label, stroke: color });
                 }
             }
 
@@ -125,8 +161,9 @@
 
             const series = [{ label: "Time" }];
             for (let i = 0; i < this.seriesCount; i++) {
-                const color = `hsl(${(i * 60) % 360}, 70%, 50%)`;
-                series.push({ label: `Channel ${i + 1}`, stroke: color });
+                const color = this.channelColors[i] || `hsl(${(i * 60) % 360}, 70%, 50%)`;
+                const label = this.channelNames[i] || `Channel ${i + 1}`;
+                series.push({ label, stroke: color });
             }
 
             this.dataBuffer = [[], ...Array(this.seriesCount).fill().map(() => [])];
@@ -140,10 +177,16 @@
                 key => newSettings[key] !== this.settings[key]
             );
             const rateChanged = newSettings.refreshRate !== this.settings.refreshRate;
+            const dataChanged = newSettings.data !== this.settings.data;
 
             this.settings = newSettings;
 
-            if (needsReset && this.plot) {
+            if (dataChanged) {
+                this._parseSeriesMeta();
+                this._updateMetaFromDatasource();
+            }
+
+            if ((needsReset || dataChanged) && this.plot) {
                 this._resetPlot();
             }
             if (rateChanged) {
@@ -161,11 +204,36 @@
                 yValues = newValue;
             } else if (newValue && Array.isArray(newValue.y)) {
                 yValues = newValue.y;
+            } else if (newValue && typeof newValue === 'object') {
+                const keys = Object.keys(newValue)
+                    .filter(k => /^y\d+$/.test(k))
+                    .sort((a, b) => parseInt(a.slice(1)) - parseInt(b.slice(1)));
+                if (keys.length) {
+                    yValues = keys.map(k => newValue[k]);
+                }
+            }
+            let namesChanged = false;
+            let colorsChanged = false;
+            if (newValue && Array.isArray(newValue.channelNames)) {
+                namesChanged = JSON.stringify(newValue.channelNames) !== JSON.stringify(this.channelNames);
+                this.channelNames = newValue.channelNames;
+            } else if (this.seriesMeta.length) {
+                const before = JSON.stringify(this.channelNames);
+                this._updateMetaFromDatasource();
+                namesChanged = before !== JSON.stringify(this.channelNames);
+            }
+            if (newValue && Array.isArray(newValue.channelColors)) {
+                colorsChanged = JSON.stringify(newValue.channelColors) !== JSON.stringify(this.channelColors);
+                this.channelColors = newValue.channelColors;
+            } else if (this.seriesMeta.length) {
+                const before = JSON.stringify(this.channelColors);
+                this._updateMetaFromDatasource();
+                colorsChanged = before !== JSON.stringify(this.channelColors);
             }
 
             if (!yValues.length) return;
 
-            if (!this.plot) {
+            if (!this.plot || this.seriesCount !== yValues.length || namesChanged || colorsChanged) {
                 this.seriesCount = yValues.length;
                 this._resetPlot();
             }


### PR DESCRIPTION
## Summary
- allow naming and coloring of serial channels
- support color palettes
- use datasource names and colors in uPlot widget

## Testing
- `node -e "require('./dashboard/plugins/serialowntech.datasource.js')"`
- `node -e "require('./dashboard/plugins/uplot.widget.js')"`


------
https://chatgpt.com/codex/tasks/task_b_68703cbcb10c832194465f072e3b2511