### PR TITLE
Support datasource headers for uPlot widget

### DIFF
--- a/test_dashboards/uplot.json
+++ b/test_dashboards/uplot.json
@@ -30,17 +30,21 @@
 		}
 	],
 	"datasources": [
-		{
-			"name": "toto",
-			"type": "serialport_datasource",
-			"settings": {
-				"portPath": "/dev/ttyACM0",
-				"baudRate": 115200,
-				"separator": ":",
-				"eol": "\\r\\n",
-				"refresh": 1000
-			}
-		}
-	],
-	"columns": 3
+                {
+                        "name": "toto",
+                        "type": "serialport_datasource",
+                        "settings": {
+                                "portPath": "/dev/ttyACM0",
+                                "baudRate": 115200,
+                                "separator": ":",
+                                "eol": "\\r\\n",
+                                "refresh": 1000,
+                                "headers": [
+                                        { "label": "Chan10", "color": "#ff0000" },
+                                        { "label": "Chan9", "color": "#00ff00" }
+                                ]
+                        }
+                }
+        ],
+        "columns": 3
 }

--- a/test_dashboards/uplot2.json
+++ b/test_dashboards/uplot2.json
@@ -146,17 +146,21 @@
 		}
 	],
 	"datasources": [
-		{
-			"name": "toto",
-			"type": "serialport_datasource",
-			"settings": {
-				"portPath": "/dev/ttyACM0",
-				"baudRate": 115200,
-				"separator": ":",
-				"eol": "\\r\\n",
-				"refresh": 1000
-			}
-		}
-	],
-	"columns": 5
+                {
+                        "name": "toto",
+                        "type": "serialport_datasource",
+                        "settings": {
+                                "portPath": "/dev/ttyACM0",
+                                "baudRate": 115200,
+                                "separator": ":",
+                                "eol": "\\r\\n",
+                                "refresh": 1000,
+                                "headers": [
+                                        { "label": "Y7", "color": "#3366ff" },
+                                        { "label": "Y9", "color": "#ff9933" }
+                                ]
+                        }
+                }
+        ],
+        "columns": 5
 }


### PR DESCRIPTION
## Summary
- add headers support when plotting uPlot charts
- use datasource label and color in uPlot series
- add header definitions in test dashboards

## Testing
- `node --check dashboard/plugins/uplot.widget.js`
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_b_68712732dee8832192458bf39eba2192