### PR TITLE
Add bootstrap style and collapsible cards

### DIFF
--- a/dashboard/css/custom.css
+++ b/dashboard/css/custom.css
@@ -1,0 +1,43 @@
+#modal_overlay .modal {
+    position: absolute;
+    background-color: #2a2a2a;
+    top: 120px;
+    width: 900px;
+    margin: auto;
+    right: 0;
+    left: 0;
+    margin-bottom: 25px;
+    height: auto;
+    overflow: visible;
+}
+#modal_overlay .modal.small {
+    max-width: 500px;
+    width: 100%;
+}
+#modal_overlay .modal header {
+    background-color: #272727;
+    height: 40px;
+    margin: 0;
+    padding: 0 10px;
+    color: #8b8b8b;
+    text-transform: uppercase;
+}
+#modal_overlay .modal footer {
+    background-color: #272727;
+    height: 40px;
+    margin: 0;
+    color: #8b8b8b;
+    text-transform: uppercase;
+    clear: both;
+    text-align: right;
+}
+#modal_overlay .modal footer .text-button {
+    line-height: 40px;
+    padding-left: 15px;
+    padding-right: 15px;
+    display: inline-block;
+}
+#modal_overlay .modal section {
+    padding: 25px;
+    padding-bottom: 55px;
+}

--- a/dashboard/index-dev.html
+++ b/dashboard/index-dev.html
@@ -11,8 +11,8 @@
     <link href="lib/css/thirdparty/jquery.gridster.min.css" rel="stylesheet" />
 	<link href="lib/css/thirdparty/codemirror.css" rel="stylesheet" />
 	<link href="lib/css/thirdparty/codemirror-ambiance.css" rel="stylesheet" />
-    <link href="lib/css/freeboard/styles.css" rel="stylesheet" />
     <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/css/bootstrap.min.css" rel="stylesheet" />
+    <link href="lib/css/freeboard/styles.css" rel="stylesheet" />
     <script src="lib/js/thirdparty/head.js"></script>
     <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/js/bootstrap.bundle.min.js"></script>
     <script type="text/javascript">

--- a/dashboard/index-dev.html
+++ b/dashboard/index-dev.html
@@ -13,6 +13,7 @@
 	<link href="lib/css/thirdparty/codemirror-ambiance.css" rel="stylesheet" />
     <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/css/bootstrap.min.css" rel="stylesheet" />
     <link href="lib/css/freeboard/styles.css" rel="stylesheet" />
+    <link href="css/custom.css" rel="stylesheet" />
     <script src="lib/js/thirdparty/head.js"></script>
     <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/js/bootstrap.bundle.min.js"></script>
     <script type="text/javascript">

--- a/dashboard/index-dev.html
+++ b/dashboard/index-dev.html
@@ -12,7 +12,9 @@
 	<link href="lib/css/thirdparty/codemirror.css" rel="stylesheet" />
 	<link href="lib/css/thirdparty/codemirror-ambiance.css" rel="stylesheet" />
     <link href="lib/css/freeboard/styles.css" rel="stylesheet" />
+    <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/css/bootstrap.min.css" rel="stylesheet" />
     <script src="lib/js/thirdparty/head.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/js/bootstrap.bundle.min.js"></script>
     <script type="text/javascript">
         head.js("lib/js/thirdparty/knockout.js",
                 "lib/js/thirdparty/jquery.js",

--- a/dashboard/index.html
+++ b/dashboard/index.html
@@ -8,8 +8,10 @@
     <meta name="apple-mobile-web-app-status-bar-style" content="black" />
     <meta name="viewport" content = "width = device-width, initial-scale = 1, user-scalable = no" />
     <link href="css/freeboard.min.css" rel="stylesheet" />
+    <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/css/bootstrap.min.css" rel="stylesheet" />
     <script src="js/freeboard.thirdparty.js"></script>
     <script src="js/freeboard.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/js/bootstrap.bundle.min.js"></script>
     <script src="plugins/thirdparty/eve.js"></script>
     <script src="plugins/thirdparty/raphael.2.1.0.min.js"></script>
     <script src="plugins/thirdparty/jquery.sparkline.min.js"></script>   

--- a/dashboard/index.html
+++ b/dashboard/index.html
@@ -9,6 +9,7 @@
     <meta name="viewport" content = "width = device-width, initial-scale = 1, user-scalable = no" />
     <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/css/bootstrap.min.css" rel="stylesheet" />
     <link href="css/freeboard.min.css" rel="stylesheet" />
+    <link href="css/custom.css" rel="stylesheet" />
     <script src="js/freeboard.thirdparty.js"></script>
     <script src="js/freeboard.js"></script>
     <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/js/bootstrap.bundle.min.js"></script>

--- a/dashboard/index.html
+++ b/dashboard/index.html
@@ -7,8 +7,8 @@
     <meta name="apple-mobile-web-app-capable" content="yes" />
     <meta name="apple-mobile-web-app-status-bar-style" content="black" />
     <meta name="viewport" content = "width = device-width, initial-scale = 1, user-scalable = no" />
-    <link href="css/freeboard.min.css" rel="stylesheet" />
     <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/css/bootstrap.min.css" rel="stylesheet" />
+    <link href="css/freeboard.min.css" rel="stylesheet" />
     <script src="js/freeboard.thirdparty.js"></script>
     <script src="js/freeboard.js"></script>
     <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/js/bootstrap.bundle.min.js"></script>

--- a/dashboard/plugins/chartowntech.widget.js
+++ b/dashboard/plugins/chartowntech.widget.js
@@ -92,11 +92,22 @@
         constructor(settings) {
             this.settings = settings;
             this.chart = null;
-            this.container = $("<div class='owntech-plot' style='height:100%; width:100%; overflow-y: auto;'></div>");
+            const id = 'chartown_' + Math.random().toString(36).substr(2,5);
+            this.card = $(
+                `<div class="card h-100">
+                    <div class="card-header p-1">
+                        <a data-bs-toggle="collapse" href="#${id}" role="button" class="text-body fw-bold d-block">${this.settings.title || 'Plot'}</a>
+                    </div>
+                    <div id="${id}" class="collapse show">
+                        <div class="card-body p-0" style="height:100%; width:100%; overflow-y:auto;"></div>
+                    </div>
+                </div>`
+            );
+            this.container = this.card.find('.card-body');
         }
 
         render(containerElement) {
-            this.container.appendTo(containerElement);
+            $(containerElement).append(this.card);
 
             const canvas = $("<canvas></canvas>").css({ height: "300px", width: "100%" }).appendTo(this.container)[0];
             const ctx = canvas.getContext('2d');
@@ -248,6 +259,8 @@
 
         onSettingsChanged(newSettings) {
             this.settings = newSettings;
+            const header = this.card.find('.card-header a');
+            header.text(this.settings.title || 'Plot');
             if (this.chart && this.chart.options.plugins.title) {
                 this.chart.options.plugins.title.text = newSettings.title || '';
                 this.chart.options.plugins.title.display = !!newSettings.title;

--- a/dashboard/plugins/serialcommand.widget.js
+++ b/dashboard/plugins/serialcommand.widget.js
@@ -32,12 +32,23 @@
     class SerialCommandButtons {
         constructor(settings) {
             this.settings = settings;
-            this.container = $('<div class="serial-command-buttons"></div>');
+            const id = 'serialcmd_' + Math.random().toString(36).substr(2,5);
+            this.card = $(
+                `<div class="card h-100">
+                    <div class="card-header p-1">
+                        <a data-bs-toggle="collapse" href="#${id}" role="button" class="text-body fw-bold d-block">Serial Commands</a>
+                    </div>
+                    <div id="${id}" class="collapse show">
+                        <div class="card-body p-2"></div>
+                    </div>
+                </div>`
+            );
+            this.container = this.card.find('.card-body');
             this.ipcRenderer = window.require?.("electron")?.ipcRenderer;
         }
 
         render(containerElement) {
-            $(containerElement).append(this.container);
+            $(containerElement).append(this.card);
             this._renderButtons();
         }
 
@@ -46,16 +57,10 @@
             const layout = this.settings.layout || "vertical";
             const buttons = this.settings.buttons || [];
             buttons.forEach(cfg => {
-                const btn = $('<button></button>')
-                    .text(cfg.label || cfg.command)
-                    .css({
-                        margin: "2px",
-                        display: layout === "horizontal" ? "inline-block" : "block",
-                        width: layout === "horizontal" ? "80px" : "100%",
-                        height: "32px",
-                        boxSizing: "border-box"
-                    });
-                    btn.on('click', () => this._sendCommand(cfg.command));
+                const btn = $(
+                    `<button class="btn btn-primary btn-sm${layout === 'horizontal' ? ' me-1' : ' mb-1 w-100'}">${cfg.label || cfg.command}</button>`
+                );
+                btn.on('click', () => this._sendCommand(cfg.command));
                 this.container.append(btn);
             });
         }

--- a/dashboard/plugins/serialflash.widget.js
+++ b/dashboard/plugins/serialflash.widget.js
@@ -16,16 +16,27 @@
             this.settings = settings;
             this.ipc = window.require?.('electron')?.ipcRenderer;
             this.path = window.require?.('path');
-            this.container = $('<div style="display:flex; flex-direction:column; height:100%; gap:4px;"></div>');
-            this.portSelect = $('<select style="width:100%; box-sizing:border-box;"></select>');
-            this.refreshBtn = $('<button>Refresh Ports</button>');
-            this.fileLabel = $('<span>No file selected</span>');
-            this.fileBtn = $('<button>Select Firmware</button>');
+            const id = 'serialflasher_' + Math.random().toString(36).substr(2,5);
+            this.card = $(
+                `<div class="card h-100">
+                    <div class="card-header p-1">
+                        <a data-bs-toggle="collapse" href="#${id}" role="button" class="text-body fw-bold d-block">${this.settings.title || 'Firmware Flasher'}</a>
+                    </div>
+                    <div id="${id}" class="collapse show">
+                        <div class="card-body d-flex flex-column gap-2"></div>
+                    </div>
+                </div>`
+            );
+            this.container = this.card.find('.card-body');
+            this.portSelect = $('<select class="form-select form-select-sm"></select>');
+            this.refreshBtn = $('<button class="btn btn-secondary btn-sm">Refresh Ports</button>');
+            this.fileLabel = $('<span class="align-self-center">No file selected</span>');
+            this.fileBtn = $('<button class="btn btn-secondary btn-sm">Select Firmware</button>');
             this.selectedFilePath = null;
-            this.startBtn = $('<button>Flash Firmware</button>');
-            this.cancelBtn = $('<button style="display:none;">Cancel</button>');
+            this.startBtn = $('<button class="btn btn-primary">Flash Firmware</button>');
+            this.cancelBtn = $('<button class="btn btn-warning btn-sm" style="display:none;">Cancel</button>');
             this.progressWrapper = $('<div class="progress" style="height:20px; display:none;"><div class="progress-bar" style="width:0%"></div></div>');
-            this.logArea = $('<textarea readonly style="flex:1; width:100%; display:none; box-sizing:border-box;"></textarea>');
+            this.logArea = $('<textarea readonly class="form-control mt-2" style="flex:1; display:none;"></textarea>');
             this._progressListener = (_e, m) => this._onProgress(m);
             this._completeListener = () => this._onComplete();
         }
@@ -33,7 +44,7 @@
         render(el) {
             this._refreshPorts();
             this.refreshBtn.on('click', () => this._refreshPorts());
-            $(el).append(this.container);
+            $(el).append(this.card);
             const fileRow = $('<div style="display:flex; gap:4px;"></div>');
             fileRow.append(this.fileBtn, this.fileLabel);
             this.container.append(this.portSelect, this.refreshBtn, fileRow, this.startBtn, this.cancelBtn, this.progressWrapper, this.logArea);
@@ -113,6 +124,8 @@
 
         onSettingsChanged(newSettings) {
             this.settings = newSettings;
+            const header = this.card.find('.card-header a');
+            header.text(this.settings.title || 'Firmware Flasher');
         }
 
         onDispose() {

--- a/dashboard/plugins/serialrecord.widget.js
+++ b/dashboard/plugins/serialrecord.widget.js
@@ -65,10 +65,21 @@
             this.settings = settings;
             this.ipc = window.require?.("electron")?.ipcRenderer;
             this.isRecording = false;
-            this.container = $('<div style="height:100%; display:flex; flex-direction:column; gap:4px;"></div>');
+            const id = 'serialrec_' + Math.random().toString(36).substr(2,5);
+            this.card = $(
+                `<div class="card h-100">
+                    <div class="card-header p-1">
+                        <a data-bs-toggle="collapse" href="#${id}" role="button" class="text-body fw-bold d-block">CSV Recorder</a>
+                    </div>
+                    <div id="${id}" class="collapse show">
+                        <div class="card-body d-flex flex-column gap-2"></div>
+                    </div>
+                </div>`
+            );
+            this.container = this.card.find('.card-body');
 
             // Dropdown of available serial datasources
-            this.dsSelect = $('<select style="flex:1; box-sizing:border-box;"></select>');
+            this.dsSelect = $('<select class="form-select form-select-sm flex-grow-1"></select>');
             this._refreshDatasourceOptions();
             this.dsSelect.on('change', () => {
                 this.settings.datasource = this.dsSelect.val();
@@ -78,23 +89,23 @@
             freeboard.on && freeboard.on('config_updated', this._configHandler);
 
             const makeRow = (labelText, inputEl) => {
-                const row = $('<div style="display:flex; align-items:center; gap:4px;"></div>');
-                const label = $(`<label style="flex:1;">${labelText}</label>`);
+                const row = $('<div class="d-flex align-items-center gap-2"></div>');
+                const label = $(`<label class="flex-grow-1">${labelText}</label>`);
                 row.append(label).append(inputEl);
                 return row;
             };
 
-            this.orderSelect = $('<select style="flex:1; box-sizing:border-box;"></select>');
+            this.orderSelect = $('<select class="form-select form-select-sm flex-grow-1"></select>');
             this.orderSelect.append('<option value="old">Old data on top</option>');
             this.orderSelect.append('<option value="new">Early data on top</option>');
 
             this.headerCheck = $('<input type="checkbox">');
-            this.timeSelect = $('<select style="flex:1; box-sizing:border-box;"></select>');
+            this.timeSelect = $('<select class="form-select form-select-sm flex-grow-1"></select>');
             this.timeSelect.append('<option value="none">None</option>');
             this.timeSelect.append('<option value="relative">Relative</option>');
             this.timeSelect.append('<option value="absolute">Absolute</option>');
 
-            this.button = $('<button class="serial-rec-btn" style="width:100%; box-sizing:border-box; height:32px;"></button>').text('Start Record');
+            this.button = $('<button class="btn btn-primary w-100"></button>').text('Start Record');
             this.portPath = null;
 
             this.container.append(
@@ -108,7 +119,7 @@
 
         render(containerElement) {
             this._syncControls();
-            $(containerElement).append(this.container);
+            $(containerElement).append(this.card);
             this.button.on('click', () => this._toggleRecord());
 
             this.orderSelect.on('change', () => {

--- a/dashboard/plugins/serialterminal.widget.js
+++ b/dashboard/plugins/serialterminal.widget.js
@@ -17,13 +17,24 @@
     class SerialTerminal {
         constructor(settings) {
             this.settings = settings;
-            this.container = $('<pre class="serial-terminal" style="overflow:auto; height:100%;"></pre>');
+            const id = 'serialterm_' + Math.random().toString(36).substr(2,5);
+            this.card = $(
+                `<div class="card h-100">
+                    <div class="card-header p-1">
+                        <a data-bs-toggle="collapse" href="#${id}" role="button" class="text-body fw-bold d-block">${this.settings.title || 'Serial Terminal'}</a>
+                    </div>
+                    <div id="${id}" class="collapse show">
+                        <div class="card-body p-1" style="overflow:auto; height:100%;"></div>
+                    </div>
+                </div>`
+            );
+            this.container = this.card.find('.card-body');
             this.ipcRenderer = window.require?.("electron")?.ipcRenderer;
             this.timer = null;
         }
 
         render(containerElement) {
-            $(containerElement).append(this.container);
+            $(containerElement).append(this.card);
             this._updateTimer();
         }
 
@@ -60,8 +71,10 @@
             this.timer = setInterval(() => this._poll(), interval);
         }
 
-        onSettingsChanged(newSettings) {
+       onSettingsChanged(newSettings) {
             this.settings = newSettings;
+            const header = this.card.find('.card-header a');
+            header.text(this.settings.title || 'Serial Terminal');
             this._updateTimer();
         }
 

--- a/dashboard/plugins/uplot.UI.js
+++ b/dashboard/plugins/uplot.UI.js
@@ -12,7 +12,18 @@
     class UPlotConfigPanel {
         constructor(settings) {
             this.settings = settings;
-            this.container = $('<div style="height:100%; overflow-y:auto; padding:8px; box-sizing:border-box;"></div>');            
+            const id = 'uplotcfg_' + Math.random().toString(36).substr(2,5);
+            this.card = $(
+                `<div class="card h-100">
+                    <div class="card-header p-1">
+                        <a data-bs-toggle="collapse" href="#${id}" role="button" class="text-body fw-bold d-block">uPlot Config</a>
+                    </div>
+                    <div id="${id}" class="collapse show">
+                        <div class="card-body" style="overflow-y:auto; padding:8px; box-sizing:border-box;"></div>
+                    </div>
+                </div>`
+            );
+            this.container = this.card.find('.card-body');
             this.controls = {};
         }
 
@@ -38,9 +49,9 @@
             form.append(titleRow);
 
             const createInput = (labelText, key, type = 'text') => {
-                const wrapper = $('<div style="margin-bottom:8px; display:flex; justify-content: flex-end;"></div>');
-                const label = $(`<label style="flex:1">${labelText}</label>`);
-                const input = $(`<input type="${type}" style="width:70%; box-sizing:border-box;">`); 
+                const wrapper = $('<div class="mb-2 d-flex justify-content-end"></div>');
+                const label = $(`<label class="flex-grow-1">${labelText}</label>`);
+                const input = $(`<input type="${type}" class="form-control form-control-sm" style="width:70%;">`);
                 this.controls[key] = input;
                 wrapper.append(label).append(input);
                 return wrapper;
@@ -59,11 +70,11 @@
             legendWrapper.append(legendLabel).append(legendCheckbox);
             form.append(legendWrapper);
 
-            const btn = $('<button style="width:100%; box-sizing:border-box;">Apply Settings</button>');           
+            const btn = $('<button class="btn btn-primary w-100">Apply Settings</button>');
             btn.on('click', () => this.applySettings());
 
             this.container.append(form).append(btn);
-            $(containerElement).append(this.container);
+            $(containerElement).append(this.card);
 
             // Watch for future changes
             freeboard.on("initialized", () => this.populateWidgetDropdown());

--- a/dashboard/plugins/uplot.widget.js
+++ b/dashboard/plugins/uplot.widget.js
@@ -25,7 +25,18 @@
     class OwnTechPlotUPlot {
         constructor(settings) {
             this.settings = settings;
-            this.container = $('<div style="width:100%; height:100%; overflow:hidden;"></div>');
+            const id = 'uplot_' + Math.random().toString(36).substr(2,5);
+            this.card = $(
+                `<div class="card h-100">
+                    <div class="card-header p-1">
+                        <a data-bs-toggle="collapse" href="#${id}" role="button" class="text-body fw-bold d-block">${this.settings.title || 'Plot'}</a>
+                    </div>
+                    <div id="${id}" class="collapse show">
+                        <div class="card-body p-0" style="width:100%; height:100%; overflow:hidden;"></div>
+                    </div>
+                </div>`
+            );
+            this.container = this.card.find('.card-body');
             this.plot = null;
             this.seriesCount = 0;
             this.dataBuffer = [[], []]; // [timestamps, [series1, series2, ...]]
@@ -34,7 +45,7 @@
         }
 
         render(containerElement) {
-            this.container.appendTo(containerElement);
+            $(containerElement).append(this.card);
             this._initPlot();
         }
 
@@ -142,6 +153,9 @@
             const rateChanged = newSettings.refreshRate !== this.settings.refreshRate;
 
             this.settings = newSettings;
+
+            const header = this.card.find('.card-header a');
+            header.text(this.settings.title || 'Plot');
 
             if (needsReset && this.plot) {
                 this._resetPlot();

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
       "license": "ISC",
       "dependencies": {
         "@robloche/chartjs-plugin-streaming": "^3.1.0",
+        "bootstrap": "^5.3.2",
         "chartjs-adapter-luxon": "^1.3.1",
         "cross-spawn": "^7.0.6",
         "electron": "^36.4.0",
@@ -46,6 +47,17 @@
       "resolved": "https://registry.npmjs.org/@kurkle/color/-/color-0.3.4.tgz",
       "integrity": "sha512-M5UknZPHRu3DEDWoipU6sE8PdkZ6Z/S+v4dD+Ke8IaNlpdSQah50lz1KtcFBa2vsdOnwbbnxJwVM4wty6udA5w==",
       "peer": true
+    },
+    "node_modules/@popperjs/core": {
+      "version": "2.11.8",
+      "resolved": "https://registry.npmjs.org/@popperjs/core/-/core-2.11.8.tgz",
+      "integrity": "sha512-P1st0aksCrn9sGZhp8GMYwBnQsbvAWsZAX44oXNNvLHGqAOcoVxmjZiohstwQ7SqKnbR47akdNi+uleWD8+g6A==",
+      "license": "MIT",
+      "peer": true,
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/popperjs"
+      }
     },
     "node_modules/@robloche/chartjs-plugin-streaming": {
       "version": "3.1.0",
@@ -353,6 +365,25 @@
       "integrity": "sha512-d0II/GO9uf9lfUHH2BQsjxzRJZBdsjgsBiW4BvhWk/3qoKwQFjIDVN19PfX8F2D/r9PCMTtLWjYVCFrpeYUzsw==",
       "deprecated": "Package no longer supported. Contact Support at https://www.npmjs.com/support for more info.",
       "optional": true
+    },
+    "node_modules/bootstrap": {
+      "version": "5.3.7",
+      "resolved": "https://registry.npmjs.org/bootstrap/-/bootstrap-5.3.7.tgz",
+      "integrity": "sha512-7KgiD8UHjfcPBHEpDNg+zGz8L3LqR3GVwqZiBRFX04a1BCArZOz1r2kjly2HQ0WokqTO0v1nF+QAt8dsW4lKlw==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/twbs"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/bootstrap"
+        }
+      ],
+      "license": "MIT",
+      "peerDependencies": {
+        "@popperjs/core": "^2.11.8"
+      }
     },
     "node_modules/buffer-crc32": {
       "version": "0.2.13",
@@ -1178,6 +1209,12 @@
       "integrity": "sha512-M5UknZPHRu3DEDWoipU6sE8PdkZ6Z/S+v4dD+Ke8IaNlpdSQah50lz1KtcFBa2vsdOnwbbnxJwVM4wty6udA5w==",
       "peer": true
     },
+    "@popperjs/core": {
+      "version": "2.11.8",
+      "resolved": "https://registry.npmjs.org/@popperjs/core/-/core-2.11.8.tgz",
+      "integrity": "sha512-P1st0aksCrn9sGZhp8GMYwBnQsbvAWsZAX44oXNNvLHGqAOcoVxmjZiohstwQ7SqKnbR47akdNi+uleWD8+g6A==",
+      "peer": true
+    },
     "@robloche/chartjs-plugin-streaming": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/@robloche/chartjs-plugin-streaming/-/chartjs-plugin-streaming-3.1.0.tgz",
@@ -1372,6 +1409,12 @@
       "resolved": "https://registry.npmjs.org/boolean/-/boolean-3.2.0.tgz",
       "integrity": "sha512-d0II/GO9uf9lfUHH2BQsjxzRJZBdsjgsBiW4BvhWk/3qoKwQFjIDVN19PfX8F2D/r9PCMTtLWjYVCFrpeYUzsw==",
       "optional": true
+    },
+    "bootstrap": {
+      "version": "5.3.7",
+      "resolved": "https://registry.npmjs.org/bootstrap/-/bootstrap-5.3.7.tgz",
+      "integrity": "sha512-7KgiD8UHjfcPBHEpDNg+zGz8L3LqR3GVwqZiBRFX04a1BCArZOz1r2kjly2HQ0WokqTO0v1nF+QAt8dsW4lKlw==",
+      "requires": {}
     },
     "buffer-crc32": {
       "version": "0.2.13",

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "justgage": "^1.7.0",
     "luxon": "^3.6.1",
     "raphael": "^2.3.0",
-    "serialport": "^13.0.0"
+    "serialport": "^13.0.0",
+    "bootstrap": "^5.3.2"
   }
 }


### PR DESCRIPTION
## Summary
- integrate bootstrap CDN into dashboard pages
- wrap widgets in bootstrap cards for a uniform look
- add bootstrap form styling for widget controls

## Testing
- `npm install`
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_b_687668cf95f483219064bc55b7daf5ad