### PR TITLE
Add datasource selector to serial command widget

### DIFF
--- a/dashboard/plugins/serialcommand.widget.js
+++ b/dashboard/plugins/serialcommand.widget.js
@@ -22,6 +22,11 @@
                     { name: "Horizontal", value: "horizontal" }
                 ],
                 default_value: "vertical"
+            },
+            {
+                name: "datasource",
+                display_name: "Datasource Name",
+                type: "text"
             }
         ],
         newInstance: function (settings, newInstanceCallback) {
@@ -32,17 +37,49 @@
     class SerialCommandButtons {
         constructor(settings) {
             this.settings = settings;
-            this.container = $('<div class="serial-command-buttons"></div>');
             this.ipcRenderer = window.require?.("electron")?.ipcRenderer;
+            this.container = $('<div class="serial-command-buttons" style="display:flex; flex-direction:column; gap:4px;"></div>');
+            this.dsSelect = $('<select style="width:100%; box-sizing:border-box;"></select>');
+            this.btnContainer = $('<div></div>');
+            this._configHandler = () => this._refreshDatasourceOptions();
+            freeboard.on && freeboard.on('config_updated', this._configHandler);
         }
 
         render(containerElement) {
             $(containerElement).append(this.container);
+            this.container.append(this.dsSelect, this.btnContainer);
+            this.dsSelect.on('change', () => {
+                this.settings.datasource = this.dsSelect.val();
+            });
+            this._refreshDatasourceOptions();
+            if (this.settings.datasource) {
+                this.dsSelect.val(this.settings.datasource);
+            }
             this._renderButtons();
         }
 
+        _refreshDatasourceOptions() {
+            const live = freeboard.getLiveModel?.();
+            if (!live || typeof live.datasources !== 'function') return;
+            const list = live.datasources();
+            const current = this.settings.datasource;
+            this.dsSelect.empty();
+            list.forEach(ds => {
+                try {
+                    if (ds.type && ds.type() === 'serialport_datasource') {
+                        const name = ds.name();
+                        this.dsSelect.append(`<option value="${name}">${name}</option>`);
+                    }
+                } catch (e) { /* ignore */ }
+            });
+            if (current && this.dsSelect.find(`option[value='${current}']`).length === 0) {
+                this.dsSelect.append(`<option value="${current}">${current}</option>`);
+            }
+            this.dsSelect.val(current);
+        }
+
         _renderButtons() {
-            this.container.empty();
+            this.btnContainer.empty();
             const layout = this.settings.layout || "vertical";
             const buttons = this.settings.buttons || [];
             buttons.forEach(cfg => {
@@ -55,30 +92,42 @@
                         height: "32px",
                         boxSizing: "border-box"
                     });
-                    btn.on('click', () => this._sendCommand(cfg.command));
-                this.container.append(btn);
+                btn.on('click', () => this._sendCommand(cfg.command));
+                this.btnContainer.append(btn);
             });
         }
 
         _sendCommand(command) {
             if (!this.ipcRenderer || !command) return;
-            this.ipcRenderer.invoke("write-serial-port", { data: command })
+            const dsSettings = freeboard.getDatasourceSettings(this.settings.datasource) || {};
+            const path = dsSettings.portPath || this.settings.datasource;
+            const payload = { data: command };
+            if (path) payload.path = path;
+            this.ipcRenderer.invoke("write-serial-port", payload)
                 .catch(err => console.error("Serial command failed:", err));
         }
 
         onSettingsChanged(newSettings) {
             this.settings = newSettings;
+            this._refreshDatasourceOptions();
             this._renderButtons();
         }
 
-        onDispose() {}
+        onDispose() {
+            if (this._configHandler && freeboard.off) {
+                freeboard.off('config_updated', this._configHandler);
+            }
+        }
 
         getHeight() {
             const count = Array.isArray(this.settings.buttons) ? this.settings.buttons.length : 1;
+            let rows = 1; // datasource selector row
             if (this.settings.layout === "horizontal") {
-                return 1;
+                rows += 1;
+            } else {
+                rows += Math.max(1, count);
             }
-            return Math.max(1, count);
+            return rows;
         }
     }
 })();

--- a/test_dashboards/uplot2.json
+++ b/test_dashboards/uplot2.json
@@ -96,6 +96,7 @@
 					"type": "serial_command_buttons",
 					"settings": {
 						"layout": "vertical",
+                                                "datasource": "toto",
 						"buttons": [
 							{
 								"label": "Power",


### PR DESCRIPTION
## Summary
- allow selecting a serial datasource for the `serial_command_buttons` widget
- update sample dashboard to include the datasource setting

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_b_68766d2bf2188321be8a26419b6e0756