### PR TITLE
Fix serial datasource buffer per-port

### DIFF
--- a/dashboard/plugins/serialowntech.datasource.js
+++ b/dashboard/plugins/serialowntech.datasource.js
@@ -72,7 +72,7 @@
 
                 async function pollData() {
                         try {
-                                const data = await ipcRenderer.invoke("get-serial-buffer");
+                                const data = await ipcRenderer.invoke("get-serial-buffer", { path: currentSettings.portPath });
                                 if (Array.isArray(data)) {
                                         latestData = data;
                                         ensureHeaderCount(latestData.length);


### PR DESCRIPTION
## Summary
- isolate serial buffers per port in `main.js`
- request port-specific data from `serialport_datasource`

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_b_6876789b5f5883219f169015b85f91d3