### PR TITLE
Fix uPlot title change

### DIFF
--- a/dashboard/plugins/uplot.widget.js
+++ b/dashboard/plugins/uplot.widget.js
@@ -140,11 +140,16 @@
                 key => newSettings[key] !== this.settings[key]
             );
             const rateChanged = newSettings.refreshRate !== this.settings.refreshRate;
+            const titleChanged = newSettings.title !== this.settings.title;
 
             this.settings = newSettings;
 
             if (needsReset && this.plot) {
                 this._resetPlot();
+            }
+            if (titleChanged && this.plot) {
+                const tEl = this.plot.root.querySelector('.u-title');
+                if (tEl) tEl.textContent = this.settings.title || '';
             }
             if (rateChanged) {
                 this.lastRender = 0;


### PR DESCRIPTION
## Summary
- fix uPlot widget title not updating on settings change

## Testing
- `node -v`

------
https://chatgpt.com/codex/tasks/task_b_6876883f9524832181683cae857e0a94