### PR TITLE
Add collapsible widget option

### DIFF
--- a/dashboard/css/freeboard.css
+++ b/dashboard/css/freeboard.css
@@ -1295,7 +1295,15 @@ header h1 {
 }
 
 .sub-section:last-of-type {
-	border-bottom: none;
+        border-bottom: none;
+}
+
+.sub-section.collapsed {
+        height: 30px !important;
+}
+
+.sub-section.collapsed .widget {
+        display: none;
 }
 
 #pump-icon {

--- a/dashboard/index-dev.html
+++ b/dashboard/index-dev.html
@@ -144,7 +144,7 @@
             </ul>
         </header>
         <section data-bind="foreach: widgets">
-            <div class="sub-section" data-bind="css: 'sub-section-height-' + height()">
+            <div class="sub-section" data-bind="css: 'sub-section-height-' + height() + (collapsed() ? \" collapsed\" : \"\")">
                 <div class="widget" data-bind="widget: true, css:{fillsize:fillSize}"></div>
                 <div class="sub-section-tools">
                     <ul class="board-toolbar">
@@ -154,6 +154,7 @@
                         <!-- ko if:$parent.widgetCanMoveDown($data) -->
                         <li data-bind="click:$parent.moveWidgetDown"><i class="icon-chevron-down icon-white"></i></li>
                         <!-- /ko -->
+                        <li data-bind="click:toggleCollapse"><i data-bind="css: collapsed() ? 'icon-plus-sign icon-white' : 'icon-minus-sign icon-white'"></i></li>
                         <li data-bind="pluginEditor: {operation: 'edit', type: 'widget'}"><i class="icon-wrench icon-white"></i></li>
                         <li data-bind="pluginEditor: {operation: 'delete', type: 'widget'}"><i class="icon-trash icon-white"></i></li>
                     </ul>

--- a/dashboard/index.html
+++ b/dashboard/index.html
@@ -143,7 +143,7 @@
             </ul>
         </header>
         <section data-bind="foreach: widgets">
-            <div class="sub-section" data-bind="css: 'sub-section-height-' + height()">
+            <div class="sub-section" data-bind="css: 'sub-section-height-' + height() + (collapsed() ? \" collapsed\" : \"\")">
                 <div class="widget" data-bind="widget: true, css:{fillsize:fillSize}"></div>
                 <div class="sub-section-tools">
                     <ul class="board-toolbar">
@@ -153,6 +153,7 @@
                         <!-- ko if:$parent.widgetCanMoveDown($data) -->
                         <li data-bind="click:$parent.moveWidgetDown"><i class="icon-chevron-down icon-white"></i></li>
                         <!-- /ko -->
+                        <li data-bind="click:toggleCollapse"><i data-bind="css: collapsed() ? 'icon-plus-sign icon-white' : 'icon-minus-sign icon-white'"></i></li>
                         <li data-bind="pluginEditor: {operation: 'edit', type: 'widget'}"><i class="icon-wrench icon-white"></i></li>
                         <li data-bind="pluginEditor: {operation: 'delete', type: 'widget'}"><i class="icon-trash icon-white"></i></li>
                     </ul>

--- a/dashboard/js/freeboard.js
+++ b/dashboard/js/freeboard.js
@@ -2239,8 +2239,17 @@ function WidgetModel(theFreeboardModel, widgetPlugins) {
 	this.datasourceRefreshNotifications = {};
 	this.calculatedSettingScripts = {};
 
-	this.title = ko.observable();
-	this.fillSize = ko.observable(false);
+        this.title = ko.observable();
+        this.fillSize = ko.observable(false);
+        this.collapsed = ko.observable(false);
+
+        this.toggleCollapse = function(){
+                self.collapsed(!self.collapsed());
+                self._heightUpdate.valueHasMutated();
+                if(typeof freeboardUI !== 'undefined') {
+                        freeboardUI.processResize(true);
+                }
+        };
 
 	this.type = ko.observable();
 	this.type.subscribe(function (newValue) {
@@ -2395,18 +2404,22 @@ function WidgetModel(theFreeboardModel, widgetPlugins) {
 		});
 	}
 
-	this._heightUpdate = ko.observable();
-	this.height = ko.computed({
-		read: function () {
-			self._heightUpdate();
+        this._heightUpdate = ko.observable();
+        this.height = ko.computed({
+                read: function () {
+                        self._heightUpdate();
 
-			if (!_.isUndefined(self.widgetInstance) && _.isFunction(self.widgetInstance.getHeight)) {
-				return self.widgetInstance.getHeight();
-			}
+                        if(self.collapsed()) {
+                                return 0;
+                        }
 
-			return 1;
-		}
-	});
+                        if (!_.isUndefined(self.widgetInstance) && _.isFunction(self.widgetInstance.getHeight)) {
+                                return self.widgetInstance.getHeight();
+                        }
+
+                        return 1;
+                }
+        });
 
 	this.shouldRender = ko.observable(false);
 	this.render = function (element) {
@@ -2421,19 +2434,21 @@ function WidgetModel(theFreeboardModel, widgetPlugins) {
 
 	}
 
-	this.serialize = function () {
-		return {
-			title: self.title(),
-			type: self.type(),
-			settings: self.settings()
-		};
-	}
+        this.serialize = function () {
+                return {
+                        title: self.title(),
+                        type: self.type(),
+                        settings: self.settings(),
+                        collapsed: self.collapsed()
+                };
+        }
 
-	this.deserialize = function (object) {
-		self.title(object.title);
-		self.settings(object.settings);
-		self.type(object.type);
-	}
+        this.deserialize = function (object) {
+                self.title(object.title);
+                self.settings(object.settings);
+                self.type(object.type);
+                self.collapsed(object.collapsed || false);
+        }
 }
 
 // ┌────────────────────────────────────────────────────────────────────┐ \\

--- a/dashboard/lib/css/freeboard/styles.css
+++ b/dashboard/lib/css/freeboard/styles.css
@@ -945,7 +945,15 @@ header h1 {
 }
 
 .sub-section:last-of-type {
-	border-bottom: none;
+        border-bottom: none;
+}
+
+.sub-section.collapsed {
+        height: 30px !important;
+}
+
+.sub-section.collapsed .widget {
+        display: none;
 }
 
 #pump-icon {

--- a/dashboard/lib/js/freeboard/WidgetModel.js
+++ b/dashboard/lib/js/freeboard/WidgetModel.js
@@ -14,8 +14,17 @@ function WidgetModel(theFreeboardModel, widgetPlugins) {
 	this.datasourceRefreshNotifications = {};
 	this.calculatedSettingScripts = {};
 
-	this.title = ko.observable();
-	this.fillSize = ko.observable(false);
+        this.title = ko.observable();
+        this.fillSize = ko.observable(false);
+        this.collapsed = ko.observable(false);
+
+        this.toggleCollapse = function(){
+                self.collapsed(!self.collapsed());
+                self._heightUpdate.valueHasMutated();
+                if(typeof freeboardUI !== 'undefined') {
+                        freeboardUI.processResize(true);
+                }
+        };
 
 	this.type = ko.observable();
 	this.type.subscribe(function (newValue) {
@@ -170,18 +179,22 @@ function WidgetModel(theFreeboardModel, widgetPlugins) {
 		});
 	}
 
-	this._heightUpdate = ko.observable();
-	this.height = ko.computed({
-		read: function () {
-			self._heightUpdate();
+        this._heightUpdate = ko.observable();
+        this.height = ko.computed({
+                read: function () {
+                        self._heightUpdate();
 
-			if (!_.isUndefined(self.widgetInstance) && _.isFunction(self.widgetInstance.getHeight)) {
-				return self.widgetInstance.getHeight();
-			}
+                        if(self.collapsed()) {
+                                return 0;
+                        }
 
-			return 1;
-		}
-	});
+                        if (!_.isUndefined(self.widgetInstance) && _.isFunction(self.widgetInstance.getHeight)) {
+                                return self.widgetInstance.getHeight();
+                        }
+
+                        return 1;
+                }
+        });
 
 	this.shouldRender = ko.observable(false);
 	this.render = function (element) {
@@ -196,17 +209,19 @@ function WidgetModel(theFreeboardModel, widgetPlugins) {
 
 	}
 
-	this.serialize = function () {
-		return {
-			title: self.title(),
-			type: self.type(),
-			settings: self.settings()
-		};
-	}
+       this.serialize = function () {
+               return {
+                       title: self.title(),
+                       type: self.type(),
+                        settings: self.settings(),
+                        collapsed: self.collapsed()
+               };
+       }
 
-	this.deserialize = function (object) {
-		self.title(object.title);
-		self.settings(object.settings);
-		self.type(object.type);
-	}
+       this.deserialize = function (object) {
+               self.title(object.title);
+               self.settings(object.settings);
+               self.type(object.type);
+                self.collapsed(object.collapsed || false);
+       }
 }


### PR DESCRIPTION
## Summary
- add collapsed styles for widgets
- add toggleCollapse logic to WidgetModel
- expose collapsed state when serializing
- wire collapse icon in dashboard templates

## Testing
- `node --check dashboard/js/freeboard.js`
- `node --check dashboard/lib/js/freeboard/WidgetModel.js`


------
https://chatgpt.com/codex/tasks/task_b_68767a622d5083219fa86d9bdf229607