### PR TITLE
Fix plot widget sizing

### DIFF
--- a/dashboard/plugins/chartowntech.widget.js
+++ b/dashboard/plugins/chartowntech.widget.js
@@ -92,14 +92,14 @@
         constructor(settings) {
             this.settings = settings;
             this.chart = null;
-            this.container = $("<div class='owntech-plot' style='height:100%; width:100%; overflow-y: auto;'></div>");
+            this.container = $("<div class='owntech-plot' style='height:100%; width:100%; display:flex; flex-direction:column; overflow:hidden;'></div>");
         }
 
         render(containerElement) {
             this.container.appendTo(containerElement);
 
             const canvas = $("<canvas></canvas>")
-                .css({ height: "100%", width: "100%" })
+                .css({ width: "100%", flex: "1 1 auto" })
                 .appendTo(this.container)[0];
             const ctx = canvas.getContext('2d');
 
@@ -146,7 +146,7 @@
 
             // Add configuration table below chart
             const configHTML = `
-                <div class="chart-config-panel" style="margin-top: 10px;">
+                <div class="chart-config-panel" style="margin-top: 10px; flex-shrink:0;">
                     <table style="width: 100%; font-size: 12px;" border="1" cellspacing="0" cellpadding="4">
                         <thead>
                             <tr>

--- a/dashboard/plugins/chartowntech.widget.js
+++ b/dashboard/plugins/chartowntech.widget.js
@@ -98,7 +98,9 @@
         render(containerElement) {
             this.container.appendTo(containerElement);
 
-            const canvas = $("<canvas></canvas>").css({ height: "300px", width: "100%" }).appendTo(this.container)[0];
+            const canvas = $("<canvas></canvas>")
+                .css({ height: "100%", width: "100%" })
+                .appendTo(this.container)[0];
             const ctx = canvas.getContext('2d');
 
             // Chart.js setup
@@ -234,16 +236,17 @@
         }
 
         _resizePlot() {
-            if (this.plot && this.container.is(":visible")) {
-                this.plot.setSize({
-                    width: this.container.width(),
-                    height: this.container.height()
-                });
+            if (this.chart && this.container.is(":visible")) {
+                this.chart.resize();
             }
         }
 
         getHeight() {
             return 6; // You can customize this based on preference
+        }
+
+        onSizeChanged() {
+            this._resizePlot();
         }
 
         onSettingsChanged(newSettings) {

--- a/dashboard/plugins/chartowntech.widget.js
+++ b/dashboard/plugins/chartowntech.widget.js
@@ -93,6 +93,7 @@
             this.settings = settings;
             this.chart = null;
             this.container = $("<div class='owntech-plot' style='height:100%; width:100%; display:flex; flex-direction:column; overflow:hidden;'></div>");
+            this.resizeObserver = null;
         }
 
         render(containerElement) {
@@ -163,6 +164,11 @@
                 </div>
             `;
             this.container.append(configHTML);
+
+            if (window.ResizeObserver) {
+                this.resizeObserver = new ResizeObserver(() => this._resizePlot());
+                this.resizeObserver.observe(this.container[0]);
+            }
         }
 
         updateLegendConfigUI() {
@@ -313,6 +319,10 @@
         }
 
         onDispose() {
+            if (this.resizeObserver) {
+                this.resizeObserver.disconnect();
+                this.resizeObserver = null;
+            }
             if (this.chart) {
                 this.chart.destroy();
             }

--- a/dashboard/plugins/uplot.widget.js
+++ b/dashboard/plugins/uplot.widget.js
@@ -188,5 +188,14 @@
         getHeight() {
             return 6;
         }
+
+        onSizeChanged() {
+            if (this.plot) {
+                this.plot.setSize({
+                    width: this.container.width(),
+                    height: this.container.height()
+                });
+            }
+        }
     }
 })();

--- a/dashboard/plugins/uplot.widget.js
+++ b/dashboard/plugins/uplot.widget.js
@@ -25,17 +25,22 @@
     class OwnTechPlotUPlot {
         constructor(settings) {
             this.settings = settings;
-            this.container = $('<div style="width:100%; height:100%; overflow:hidden;"></div>');
+            this.container = $('<div style="width:100%; height:100%; display:flex; flex-direction:column; overflow:hidden;"></div>');
             this.plot = null;
             this.seriesCount = 0;
             this.dataBuffer = [[], []]; // [timestamps, [series1, series2, ...]]
             this.maxPoints = 2000;
             this.lastRender = 0;
+            this.resizeObserver = null;
         }
 
         render(containerElement) {
             this.container.appendTo(containerElement);
             this._initPlot();
+            if (window.ResizeObserver) {
+                this.resizeObserver = new ResizeObserver(() => this.onSizeChanged());
+                this.resizeObserver.observe(this.container[0]);
+            }
         }
 
         _initPlot(series = null) {
@@ -179,6 +184,10 @@
         }
 
         onDispose() {
+            if (this.resizeObserver) {
+                this.resizeObserver.disconnect();
+                this.resizeObserver = null;
+            }
             if (this.plot) {
                 this.plot.destroy();
                 this.plot = null;


### PR DESCRIPTION
## Summary
- ensure chart widget canvas fills its container
- allow chart widget to resize when widget size changes
- allow uPlot widget to resize when widget size changes

## Testing
- `bash dashboard/test/run_browser_tests.sh` *(fails: libproviders.so missing)*

------
https://chatgpt.com/codex/tasks/task_b_6877653628948321a5ad5b31abcf78e0