### PR TITLE
Improve terminal widget styling

### DIFF
--- a/dashboard/plugins/serialterminal.widget.js
+++ b/dashboard/plugins/serialterminal.widget.js
@@ -29,7 +29,10 @@
             const colorBox = $('<span class="input-group-text"></span>').append(this.colorCheck);
             colorWrapper.append(colorLabel).append(colorBox);
             this.codeEl = $('<code></code>');
-            this.preEl = $('<pre class="serial-terminal" style="overflow:auto; flex:1; margin:0;"></pre>').append(this.codeEl);
+            this.preEl = $(
+                '<pre class="serial-terminal border border-secondary rounded bg-dark text-light p-2" ' +
+                'style="overflow:auto; flex:1; margin:0;"></pre>'
+            ).append(this.codeEl);
             const dsRow = $('<div class="input-group input-group-sm mb-1"></div>');
             dsRow.append('<span class="input-group-text">Datasource</span>', this.dsSelect);
             this.container.append(dsRow, colorWrapper, this.preEl);


### PR DESCRIPTION
## Summary
- style serial terminal widget with a bordered code box so the output appears like a snippet

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_b_687817d1ff088321867864ff6f8e9a07