### PR TITLE
Add npm test hook and agent guide

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,9 @@
+# AGENT Instructions
+
+When modifying any code for this project:
+
+1. Install dependencies with `npm install` if not already done.
+2. Run the smoke tests using `npm test`. This executes `dashboard/test/run_browser_tests.sh` which runs the CasperJS tests.
+3. Verify the Electron dashboard launches by running `npm start`.
+
+Always ensure `npm test` completes successfully before committing changes that affect dashboard functionality.

--- a/package.json
+++ b/package.json
@@ -4,7 +4,8 @@
   "description": "",
   "main": "main.js",
   "scripts": {
-    "start": "electron ."
+    "start": "electron .",
+    "test": "cd dashboard/test && sh ./run_browser_tests.sh"
   },
   "keywords": [],
   "author": "",
@@ -20,5 +21,9 @@
     "luxon": "^3.6.1",
     "raphael": "^2.3.0",
     "serialport": "^13.0.0"
+  },
+  "devDependencies": {
+    "casperjs": "^1.1.4",
+    "phantomjs-prebuilt": "^2.1.16"
   }
 }


### PR DESCRIPTION
## Summary
- add dev deps for casperjs + phantomjs
- run smoke test via `npm test`
- document development steps in AGENTS guide
- revert inadvertent `package-lock.json` changes

## Testing
- `npm install`
- `npm test` *(fails: `libproviders.so` missing)*
- `npm start` *(fails: Electron requires --no-sandbox)*

------
https://chatgpt.com/codex/tasks/task_b_6878151809208321b82f887a85465009