### PR TITLE
Fix CasperJS script path

### DIFF
--- a/dashboard/test/run_browser_tests.sh
+++ b/dashboard/test/run_browser_tests.sh
@@ -1,3 +1,3 @@
 cd "$( dirname "$0" )"
 cd ..
-casperjs test test/casper/tests/
+npx casperjs test test/casper/tests/


### PR DESCRIPTION
## Summary
- use `npx` for running CasperJS tests

## Testing
- `npm test` *(fails: libproviders.so missing)*
- `npm start -- --no-sandbox` *(fails: missing X server)*

------
https://chatgpt.com/codex/tasks/task_b_68782a9215748321b7e9e7287f9efaf3