### PR TITLE
Centralize default color definition

### DIFF
--- a/dashboard/plugins/chartowntech.widget.js
+++ b/dashboard/plugins/chartowntech.widget.js
@@ -1,4 +1,5 @@
 (function () {
+    const defaultColor = require('../../defaultColor');
     freeboard.loadWidgetPlugin({
         type_name: "owntech_plot",
         display_name: "OwnTech Plot",
@@ -292,8 +293,8 @@
                 const index = this.chart.data.datasets.length;
                 this.chart.data.datasets.push({
                     label: `Channel ${index + 1}`,
-                    borderColor: `hsl(${(index * 60) % 360}, 70%, 50%)`,
-                    backgroundColor: `hsla(${(index * 60) % 360}, 70%, 50%, 0.1)`,
+                    borderColor: defaultColor(index),
+                    backgroundColor: defaultColor(index).replace('hsl(', 'hsla(').replace(')', ', 0.1)'),
                     fill: false,
                     data: [],
                     borderDash: [],

--- a/dashboard/plugins/serialterminal.widget.js
+++ b/dashboard/plugins/serialterminal.widget.js
@@ -1,4 +1,5 @@
 (function () {
+    const defaultColor = require('../../defaultColor');
     freeboard.loadWidgetPlugin({
         type_name: "serial_terminal",
         display_name: "Serial Terminal",
@@ -84,7 +85,7 @@
             return lines.map(line => {
                 const parts = line.trim().split(separator).filter(p => p !== "");
                 return parts.map((p, idx) => {
-                    const color = colors[idx] || `hsl(${(idx * 60) % 360}, 70%, 50%)`;
+                    const color = colors[idx] || defaultColor(idx);
                     return `<span style="color:${color}">${p}</span>`;
                 }).join(" ");
             });

--- a/dashboard/plugins/uplot.widget.js
+++ b/dashboard/plugins/uplot.widget.js
@@ -1,4 +1,5 @@
 (function () {
+    const defaultColor = require('../../defaultColor');
     freeboard.loadWidgetPlugin({
         type_name: "owntech_plot_uplot",
         display_name: "OwnTech Plot (uPlot)",
@@ -137,7 +138,7 @@ class OwnTechPlotUPlot {
             const chIdx = mapping.idx ?? this.channelIndices[idx] ?? idx;
             const colors = this.colorsByDs[ds] || [];
             if (colors[chIdx]) return colors[chIdx];
-            return `hsl(${(idx * 60) % 360}, 70%, 50%)`;
+            return defaultColor(idx);
         }
 
         render(containerElement) {

--- a/defaultColor.js
+++ b/defaultColor.js
@@ -1,0 +1,3 @@
+module.exports = function defaultColor(idx) {
+  return `hsl(${(idx * 60) % 360}, 70%, 50%)`;
+};

--- a/main.js
+++ b/main.js
@@ -3,6 +3,7 @@ const path = require('path');
 const { SerialPort } = require('serialport');
 const fs = require('fs');
 const { flashFirmware, cancelFlash } = require('./flasher');
+const defaultColor = require('./defaultColor');
 
 let mainWindow; // reference to the main BrowserWindow
 
@@ -163,7 +164,20 @@ ipcMain.handle('set-serial-headers', (_event, { path, headers }) => {
 
 // 🎨 Get/set colors for a port
 ipcMain.handle('get-serial-colors', (_event, { path }) => {
-    return colorBuffers.get(path) || [];
+    const colors = colorBuffers.get(path);
+    if (Array.isArray(colors) && colors.length) return colors;
+
+    const headers = headerBuffers.get(path);
+    if (Array.isArray(headers) && headers.length) {
+        return headers.map((_, idx) => defaultColor(idx));
+    }
+
+    const data = serialBuffers.get(path);
+    if (Array.isArray(data) && data.length && Array.isArray(data[0])) {
+        return data[0].map((_, idx) => defaultColor(idx));
+    }
+
+    return [];
 });
 
 ipcMain.handle('set-serial-colors', (_event, { path, colors }) => {


### PR DESCRIPTION
## Summary
- create a `defaultColor` module
- use the module from Electron main process
- generate default colors from main when none are set
- update serial terminal, uPlot, and chart widgets to use the shared color function

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_b_6878ea55044c832190a82347452d5217