### PR TITLE
Add color palette selector

### DIFF
--- a/dashboard/index-dev.html
+++ b/dashboard/index-dev.html
@@ -15,6 +15,8 @@
     <link href="lib/css/freeboard/styles.css" rel="stylesheet" />
     <link href="css/bootstrap-overrides.css" rel="stylesheet" />
     <script src="lib/js/thirdparty/head.js"></script>
+    <script src="lib/js/thirdparty/colorschemes.tableau.js"></script>
+    <script src="lib/js/thirdparty/colorschemes.office.js"></script>
     <script type="text/javascript">
         head.js("lib/js/thirdparty/knockout.js",
                 "lib/js/thirdparty/jquery.js",

--- a/dashboard/index.html
+++ b/dashboard/index.html
@@ -11,6 +11,8 @@
     <link href="css/freeboard.min.css" rel="stylesheet" />
     <link href="css/bootstrap-overrides.css" rel="stylesheet" />
     <script src="js/freeboard.thirdparty.js"></script>
+    <script src="lib/js/thirdparty/colorschemes.tableau.js"></script>
+    <script src="lib/js/thirdparty/colorschemes.office.js"></script>
     <script src="js/freeboard.js"></script>
     <script src="plugins/thirdparty/eve.js"></script>
     <script src="plugins/thirdparty/raphael.2.1.0.min.js"></script>


### PR DESCRIPTION
## Summary
- update header editor widget to allow selecting color palette
- apply palette colors to header rows
- load color scheme files in HTML pages

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_b_687902dfa3d48321861c5026a549e0ea