### PR TITLE
Switch default colors to ColorBlind10

### DIFF
--- a/dashboard/plugins/chartowntech.widget.js
+++ b/dashboard/plugins/chartowntech.widget.js
@@ -292,8 +292,8 @@
                 const index = this.chart.data.datasets.length;
                 this.chart.data.datasets.push({
                     label: `Channel ${index + 1}`,
-                    borderColor: `hsl(${(index * 60) % 360}, 70%, 50%)`,
-                    backgroundColor: `hsla(${(index * 60) % 360}, 70%, 50%, 0.1)`,
+                    borderColor: (typeof ColorBlind10 !== "undefined" ? ColorBlind10[index % ColorBlind10.length] : `hsl(${(index * 60) % 360}, 70%, 50%)`),
+                    backgroundColor: (typeof ColorBlind10 !== "undefined" ? ColorBlind10[index % ColorBlind10.length] + "33" : `hsla(${(index * 60) % 360}, 70%, 50%, 0.1)`),
                     fill: false,
                     data: [],
                     borderDash: [],

--- a/dashboard/plugins/serialterminal.widget.js
+++ b/dashboard/plugins/serialterminal.widget.js
@@ -84,7 +84,7 @@
             return lines.map(line => {
                 const parts = line.trim().split(separator).filter(p => p !== "");
                 return parts.map((p, idx) => {
-                    const color = colors[idx] || `hsl(${(idx * 60) % 360}, 70%, 50%)`;
+                    const color = colors[idx] || (typeof ColorBlind10 !== "undefined" ? ColorBlind10[idx % ColorBlind10.length] : `hsl(${(idx * 60) % 360}, 70%, 50%)`);
                     return `<span style="color:${color}">${p}</span>`;
                 }).join(" ");
             });

--- a/dashboard/plugins/uplot.widget.js
+++ b/dashboard/plugins/uplot.widget.js
@@ -137,7 +137,7 @@ class OwnTechPlotUPlot {
             const chIdx = mapping.idx ?? this.channelIndices[idx] ?? idx;
             const colors = this.colorsByDs[ds] || [];
             if (colors[chIdx]) return colors[chIdx];
-            return `hsl(${(idx * 60) % 360}, 70%, 50%)`;
+            return (typeof ColorBlind10 !== "undefined" ? ColorBlind10[idx % ColorBlind10.length] : `hsl(${(idx * 60) % 360}, 70%, 50%)`);
         }
 
         render(containerElement) {


### PR DESCRIPTION
## Summary
- use ColorBlind10 palette instead of HSL fallback

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_b_68791011015c8321b033e82aa93663c9