### PR TITLE
Add global mean helper for dashboard expressions

### DIFF
--- a/dashboard/index.html
+++ b/dashboard/index.html
@@ -14,6 +14,7 @@
     <script src="lib/js/thirdparty/colorschemes.tableau.js"></script>
     <script src="lib/js/thirdparty/colorschemes.office.js"></script>
     <script src="js/freeboard.js"></script>
+    <script src="js/expr_utils.js"></script>
     <script src="plugins/thirdparty/eve.js"></script>
     <script src="plugins/thirdparty/raphael.2.1.0.min.js"></script>
     <script src="plugins/thirdparty/jquery.sparkline.min.js"></script>   

--- a/dashboard/js/expr_utils.js
+++ b/dashboard/js/expr_utils.js
@@ -1,0 +1,23 @@
+(function(){
+    const buffers = new WeakMap();
+    function getBuffer(fn){
+        let buf = buffers.get(fn);
+        if(!buf){
+            buf = [];
+            buffers.set(fn, buf);
+        }
+        return buf;
+    }
+    window.mean = function(value, windowSize){
+        windowSize = parseInt(windowSize);
+        if(isNaN(windowSize) || windowSize <= 0) windowSize = 10;
+        const caller = window.mean.caller || arguments.callee.caller;
+        const buffer = getBuffer(caller || window.mean);
+        buffer.push(value);
+        if(buffer.length > windowSize){
+            buffer.shift();
+        }
+        const sum = buffer.reduce((a,b)=>a+b,0);
+        return buffer.length ? sum / buffer.length : 0;
+    };
+})();


### PR DESCRIPTION
## Summary
- provide new `mean` helper for calculated JS expressions
- load helper in `index.html` so expressions can call `mean`

## Testing
- `node - <<'EOF'
 global.window = global; require('./dashboard/js/expr_utils.js');
 console.log(mean(1,3));
 console.log(mean(2,3));
 console.log(mean(3,3));
 console.log(mean(4,3));
 EOF`

------
https://chatgpt.com/codex/tasks/task_b_68791bfe6cec83218ebffe4fce32fcef