### PR TITLE
Add per-expression buffers for mean helper

### DIFF
--- a/dashboard/index.html
+++ b/dashboard/index.html
@@ -14,6 +14,7 @@
     <script src="lib/js/thirdparty/colorschemes.tableau.js"></script>
     <script src="lib/js/thirdparty/colorschemes.office.js"></script>
     <script src="js/freeboard.js"></script>
+    <script src="js/expr_utils.js"></script>
     <script src="plugins/thirdparty/eve.js"></script>
     <script src="plugins/thirdparty/raphael.2.1.0.min.js"></script>
     <script src="plugins/thirdparty/jquery.sparkline.min.js"></script>   

--- a/dashboard/js/expr_utils.js
+++ b/dashboard/js/expr_utils.js
@@ -16,25 +16,33 @@
         return window.mean.caller || arguments.callee.caller;
     }
 
-    function getBuffer(key){
-        let buf = buffers.get(key);
-        if(!buf){
-            buf = [];
-            buffers.set(key, buf);
+    function getEntry(key){
+        let entry = buffers.get(key);
+        if(!entry){
+            entry = { size: 0, buffer: [] };
+            buffers.set(key, entry);
         }
-        return buf;
+        return entry;
     }
 
     window.mean = function(value, windowSize){
         windowSize = parseInt(windowSize);
         if(isNaN(windowSize) || windowSize <= 0) windowSize = 10;
         const key = getKey();
-        const buffer = getBuffer(key);
-        buffer.push(value);
-        if(buffer.length > windowSize){
-            buffer.shift();
+        const entry = getEntry(key);
+
+        if(entry.size !== windowSize){
+            entry.size = windowSize;
+            if(entry.buffer.length > windowSize){
+                entry.buffer = entry.buffer.slice(-windowSize);
+            }
         }
-        const sum = buffer.reduce((a,b)=>a+b,0);
-        return buffer.length ? sum / buffer.length : 0;
+
+        entry.buffer.push(value);
+        if(entry.buffer.length > entry.size){
+            entry.buffer.shift();
+        }
+        const sum = entry.buffer.reduce((a,b)=>a+b,0);
+        return entry.buffer.length ? sum / entry.buffer.length : 0;
     };
 })();

--- a/dashboard/js/expr_utils.js
+++ b/dashboard/js/expr_utils.js
@@ -1,0 +1,40 @@
+(function(){
+    const buffers = new Map();
+
+    function getKey(){
+        const err = new Error();
+        if(err.stack){
+            const lines = err.stack.split("\n");
+            // When called from mean() via this helper, the caller is
+            // three frames up the stack.
+            if(lines.length >= 4){
+                return lines[3].trim();
+            } else if(lines.length >= 3){
+                return lines[2].trim();
+            }
+        }
+        return window.mean.caller || arguments.callee.caller;
+    }
+
+    function getBuffer(key){
+        let buf = buffers.get(key);
+        if(!buf){
+            buf = [];
+            buffers.set(key, buf);
+        }
+        return buf;
+    }
+
+    window.mean = function(value, windowSize){
+        windowSize = parseInt(windowSize);
+        if(isNaN(windowSize) || windowSize <= 0) windowSize = 10;
+        const key = getKey();
+        const buffer = getBuffer(key);
+        buffer.push(value);
+        if(buffer.length > windowSize){
+            buffer.shift();
+        }
+        const sum = buffer.reduce((a,b)=>a+b,0);
+        return buffer.length ? sum / buffer.length : 0;
+    };
+})();


### PR DESCRIPTION
## Summary
- refine dashboard `mean` helper to track buffers per call site using stack traces

## Testing
- `node - <<'EOF'
 global.window = global; require('./dashboard/js/expr_utils.js');
 const fn = new Function('datasources', 'return [mean(datasources.a,3), mean(datasources.b,3), mean(datasources.a,3)];');
 console.log(fn({a:1,b:2}));
 console.log(fn({a:2,b:3}));
 console.log(fn({a:3,b:4}));
EOF`


------
https://chatgpt.com/codex/tasks/task_b_68791bfe6cec83218ebffe4fce32fcef