### PR TITLE
Add fast frame serial datasource

### DIFF
--- a/dashboard/plugins/serialfast.datasource.js
+++ b/dashboard/plugins/serialfast.datasource.js
@@ -17,8 +17,8 @@
             if (!ipcRenderer) return;
             try {
                 const data = await ipcRenderer.invoke('get-fast-data', { path: this.settings.portPath });
-                if (data && Array.isArray(data.data)) {
-                    this.updateCallback({ frame: data.data });
+                if (data) {
+                    this.updateCallback({ frame: data });
                 }
             } catch (err) {
                 console.error('Fast data update failed:', err);

--- a/dashboard/plugins/serialfast.datasource.js
+++ b/dashboard/plugins/serialfast.datasource.js
@@ -13,6 +13,18 @@
             this._openPort();
         }
 
+        async updateNow() {
+            if (!ipcRenderer) return;
+            try {
+                const data = await ipcRenderer.invoke('get-fast-data', { path: this.settings.portPath });
+                if (data && Array.isArray(data.data)) {
+                    this.updateCallback({ frame: data.data });
+                }
+            } catch (err) {
+                console.error('Fast data update failed:', err);
+            }
+        }
+
         async _openPort() {
             if (!ipcRenderer) return;
             try {

--- a/dashboard/plugins/serialfast.datasource.js
+++ b/dashboard/plugins/serialfast.datasource.js
@@ -1,0 +1,99 @@
+(function () {
+    const ipcRenderer = window.require?.("electron")?.ipcRenderer;
+    class SerialFastDatasource {
+        constructor(settings, updateCallback) {
+            this.settings = settings;
+            this.updateCallback = updateCallback;
+            this.timer = null;
+            this.latest = null;
+            this._start();
+        }
+
+        async _openPort() {
+            if (!ipcRenderer) return;
+            try {
+                await ipcRenderer.invoke("open-serial-port", {
+                    path: this.settings.portPath,
+                    baudRate: this.settings.baudRate,
+                    separator: this.settings.separator,
+                    eol: this.settings.eol
+                });
+            } catch (e) {
+                console.error("Open serial failed:", e.message);
+            }
+        }
+
+        async _poll() {
+            if (!ipcRenderer) return;
+            try {
+                const data = await ipcRenderer.invoke('get-fast-data', { path: this.settings.portPath });
+                if (data && Array.isArray(data.data)) {
+                    this.latest = data;
+                }
+            } catch (e) {
+                console.error('Failed to get fast data:', e);
+            }
+        }
+
+        updateNow = async () => {
+            await this._poll();
+            if (this.latest) {
+                this.updateCallback(this.latest);
+            }
+        };
+
+        onDispose() {
+            if (this.timer) clearInterval(this.timer);
+            if (ipcRenderer && this.settings.portPath) {
+                ipcRenderer.invoke('close-serial-port', { path: this.settings.portPath }).catch(() => {});
+            }
+        }
+
+        onSettingsChanged(newSettings) {
+            this.settings = newSettings;
+            this._openPort();
+            this._startTimer();
+        }
+
+        _startTimer() {
+            if (this.timer) clearInterval(this.timer);
+            const interval = parseInt(this.settings.refresh) || 1000;
+            this.timer = setInterval(() => this.updateNow(), interval);
+        }
+
+        _start() {
+            this._openPort();
+            this._startTimer();
+        }
+    }
+
+    async function registerPlugin() {
+        let portOptions = [];
+        if (ipcRenderer) {
+            try {
+                const ports = await ipcRenderer.invoke('get-serial-ports');
+                portOptions = ports.map(p => ({ name: p.name, value: p.value }));
+            } catch (e) {
+                console.error('Failed to list serial ports', e);
+            }
+        }
+
+        freeboard.loadDatasourcePlugin({
+            type_name: 'serialfast_datasource',
+            display_name: 'Fast Serial Frame',
+            description: 'Reads fast frame data from a serial port',
+            settings: [
+                { name: 'portPath', display_name: 'Port', type: 'option', options: portOptions, default_value: portOptions.length ? portOptions[0].value : '' },
+                { name: 'baudRate', display_name: 'Baud Rate', type: 'number', default_value: 115200 },
+                { name: 'separator', display_name: 'Separator', type: 'text', default_value: ':' },
+                { name: 'eol', display_name: 'End of Line', type: 'text', default_value: '\\r\\n' },
+                { name: 'refresh', display_name: 'Refresh Every', type: 'number', suffix: 'ms', default_value: 1000 }
+            ],
+            newInstance: function (settings, newInstanceCallback, updateCallback) {
+                newInstanceCallback(new SerialFastDatasource(settings, updateCallback));
+            }
+        });
+    }
+
+    registerPlugin();
+})();


### PR DESCRIPTION
## Summary
- parse fast-frame sequences on serial ports
- expose parsed fast-frame data via new IPC call
- add datasource plugin to fetch fast-frame data

## Testing
- `node --check main.js`
- `node --check dashboard/plugins/serialfast.datasource.js`
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_b_687a2fbac89c8321a716bdf0f3cd05dc