### PR TITLE
Fix config panel defaults when single plot exists

### DIFF
--- a/dashboard/plugins/uplot.UI.js
+++ b/dashboard/plugins/uplot.UI.js
@@ -132,6 +132,12 @@
 
         if (selected && titleSelect.find(`option[value="${selected}"]`).length) {
             titleSelect.val(selected);
+        } else if (!selected && widgets.length === 1) {
+            titleSelect.val(widgets[0]);
+        }
+
+        if (titleSelect.val()) {
+            this.syncFromSelectedWidget();
         }
     }
 

--- a/dashboard/plugins/uplot.UI.js
+++ b/dashboard/plugins/uplot.UI.js
@@ -97,8 +97,16 @@
             this.controls.duration.val(typeof settings.duration === "function" ? settings.duration() : settings.duration || 20000);
             this.controls.refreshRate.val(typeof settings.refreshRate === "function" ? settings.refreshRate() : settings.refreshRate || 1000);
             this.controls.yLabel.val(typeof settings.yLabel === "function" ? settings.yLabel() : settings.yLabel || "");
-            this.controls.yMin.val(typeof settings.yMin === "function" ? settings.yMin() : settings.yMin || "");
-            this.controls.yMax.val(typeof settings.yMax === "function" ? settings.yMax() : settings.yMax || "");
+            this.controls.yMin.val(
+                typeof settings.yMin === "function"
+                    ? settings.yMin()
+                    : (settings.yMin ?? "")
+            );
+            this.controls.yMax.val(
+                typeof settings.yMax === "function"
+                    ? settings.yMax()
+                    : (settings.yMax ?? "")
+            );
             this.controls.showLegend.prop("checked", !!(
                 typeof settings.showLegend === "function" ? settings.showLegend() : settings.showLegend
             ));


### PR DESCRIPTION
## Summary
- fix uPlot config panel initial field population when only one plot widget exists

## Testing
- `npm test` *(fails: Missing script)*
- `node --check dashboard/plugins/uplot.UI.js`


------
https://chatgpt.com/codex/tasks/task_b_687e390f33448321b2ea7092aa2350b7