### PR TITLE
Separate serial labels by datasource type

### DIFF
--- a/dashboard/plugins/serialfast.datasource.js
+++ b/dashboard/plugins/serialfast.datasource.js
@@ -11,7 +11,8 @@
                     path: currentSettings.portPath,
                     baudRate: currentSettings.baudRate,
                     separator: currentSettings.separator,
-                    eol: currentSettings.eol
+                    eol: currentSettings.eol,
+                    type: 'fast_frame_datasource'
                 });
             } catch (e) {
                 console.error('Open serial failed:', e.message);

--- a/dashboard/plugins/serialheaders.widget.js
+++ b/dashboard/plugins/serialheaders.widget.js
@@ -142,8 +142,9 @@
             if (this.ipc) {
                 try {
                     const path = await this._getPortPath();
-                    headers = await this.ipc.invoke('get-serial-headers', { path });
-                    colors = await this.ipc.invoke('get-serial-colors', { path });
+                    const type = this._getDatasourceType();
+                    headers = await this.ipc.invoke('get-serial-headers', { path, type });
+                    colors = await this.ipc.invoke('get-serial-colors', { path, type });
                 } catch (e) { /* ignore */ }
             }
             if (!Array.isArray(headers) || !headers.length) {
@@ -184,8 +185,9 @@
             if (this.ipc) {
                 try {
                     const path = await this._getPortPath();
-                    await this.ipc.invoke('set-serial-headers', { path, headers: clean });
-                    await this.ipc.invoke('set-serial-colors', { path, colors });
+                    const type = this._getDatasourceType();
+                    await this.ipc.invoke('set-serial-headers', { path, type, headers: clean });
+                    await this.ipc.invoke('set-serial-colors', { path, type, colors });
                 } catch (e) { console.error('Failed to set headers', e); }
             }
         }

--- a/dashboard/plugins/serialowntech.datasource.js
+++ b/dashboard/plugins/serialowntech.datasource.js
@@ -13,12 +13,13 @@
 		async function openPort() {
 			if (!ipcRenderer) return;
 			try {
-				await ipcRenderer.invoke("open-serial-port", {
-					path: currentSettings.portPath,
-					baudRate: currentSettings.baudRate,
-					separator: currentSettings.separator,
-					eol: currentSettings.eol
-				});
+                                await ipcRenderer.invoke("open-serial-port", {
+                                        path: currentSettings.portPath,
+                                        baudRate: currentSettings.baudRate,
+                                        separator: currentSettings.separator,
+                                        eol: currentSettings.eol,
+                                        type: 'serialport_datasource'
+                                });
 			} catch (e) {
 				console.error("Open serial failed:", e.message);
 			}

--- a/dashboard/plugins/serialportcontrol.widget.js
+++ b/dashboard/plugins/serialportcontrol.widget.js
@@ -92,7 +92,8 @@
                     path,
                     baudRate: dsSettings.baudRate,
                     separator: dsSettings.separator,
-                    eol: dsSettings.eol
+                    eol: dsSettings.eol,
+                    type: 'serialport_datasource'
                 }).catch(() => {});
                 this.isOpen = true;
             }

--- a/dashboard/plugins/serialterminal.widget.js
+++ b/dashboard/plugins/serialterminal.widget.js
@@ -100,8 +100,9 @@
             }
             const ds = freeboard.getDatasourceSettings(this.settings.datasourceName) || {};
             const path = ds.portPath || this.settings.datasourceName;
+            const type = this._getDatasourceType(this.settings.datasourceName);
             try {
-                const fetched = await this.ipcRenderer.invoke('get-serial-colors', { path });
+                const fetched = await this.ipcRenderer.invoke('get-serial-colors', { path, type });
                 if (Array.isArray(fetched) && fetched.length) {
                     this.colors = fetched;
                     return;
@@ -132,6 +133,20 @@
                 this.dsSelect.append(`<option value="${current}">${current}</option>`);
             }
             this.dsSelect.val(current);
+        }
+
+        _getDatasourceType(name) {
+            const live = freeboard.getLiveModel?.();
+            if (!live || typeof live.datasources !== 'function') return null;
+            const list = live.datasources();
+            for (const ds of list) {
+                try {
+                    if (ds.name && ds.name() === name) {
+                        return ds.type?.();
+                    }
+                } catch (e) { /* ignore */ }
+            }
+            return null;
         }
 
         _updateTimer() {

--- a/dashboard/plugins/uplot.widget.js
+++ b/dashboard/plugins/uplot.widget.js
@@ -71,12 +71,27 @@ class OwnTechPlotUPlot {
             }
         }
 
+        _getDatasourceType(name) {
+            const live = freeboard.getLiveModel?.();
+            if (!live || typeof live.datasources !== 'function') return null;
+            const list = live.datasources();
+            for (const ds of list) {
+                try {
+                    if (ds.name && ds.name() === name) {
+                        return ds.type?.();
+                    }
+                } catch (e) { /* ignore */ }
+            }
+            return null;
+        }
+
         async _fetchHeaders(dsName) {
             if (!this.ipc || !dsName) return [];
             const dsSettings = freeboard.getDatasourceSettings(dsName) || {};
             const path = dsSettings.portPath || dsName;
+            const type = this._getDatasourceType(dsName);
             try {
-                const headers = await this.ipc.invoke('get-serial-headers', { path });
+                const headers = await this.ipc.invoke('get-serial-headers', { path, type });
                 return Array.isArray(headers) ? headers : [];
             } catch (e) {
                 console.error('header fetch failed', e);
@@ -88,8 +103,9 @@ class OwnTechPlotUPlot {
             if (!this.ipc || !dsName) return [];
             const dsSettings = freeboard.getDatasourceSettings(dsName) || {};
             const path = dsSettings.portPath || dsName;
+            const type = this._getDatasourceType(dsName);
             try {
-                const colors = await this.ipc.invoke('get-serial-colors', { path });
+                const colors = await this.ipc.invoke('get-serial-colors', { path, type });
                 if (Array.isArray(colors) && colors.length) return colors;
             } catch (e) {
                 console.error('color fetch failed', e);


### PR DESCRIPTION
## Summary
- allow multiple datasources on the same serial port to keep individual labels and colours
- send datasource type when opening ports or editing headers/colours

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_b_687e4f938e6483218971c8154ce200d3