### PR TITLE
Add CSV file datasource plugin

### DIFF
--- a/dashboard/index.html
+++ b/dashboard/index.html
@@ -32,6 +32,7 @@
             "plugins/serialflash.widget.js",
             "plugins/serialheaders.widget.js",
             "plugins/serialfast.datasource.js",
+            "plugins/csvfile.datasource.js",
             "plugins/serialowntech.datasource.js",
             "js/dashboard_control.js",
             "plugins/uplot.UI.js",

--- a/dashboard/plugins/csvfile.datasource.js
+++ b/dashboard/plugins/csvfile.datasource.js
@@ -1,0 +1,106 @@
+(function () {
+    const fs = window.require?.('fs');
+    const ipc = window.require?.('electron')?.ipcRenderer;
+
+    function parseCsv(text, sep, hasHeader) {
+        const lines = text.split(/\r?\n/).filter(l => l.trim() !== '');
+        if (!lines.length) return { timestamps: [], series: [] };
+
+        let start = 0;
+        if (hasHeader) {
+            start = 1;
+        }
+        const first = lines[start] || '';
+        const count = first.split(sep).length;
+        const cols = Array.from({ length: count }, () => []);
+        for (let i = start; i < lines.length; i++) {
+            const parts = lines[i].split(sep);
+            for (let j = 0; j < count; j++) {
+                const val = parts[j] || '';
+                if (j === 0) {
+                    const num = parseFloat(val);
+                    cols[j].push(isNaN(num) ? Date.parse(val) || 0 : num);
+                } else {
+                    const f = parseFloat(val);
+                    cols[j].push(isNaN(f) ? null : f);
+                }
+            }
+        }
+        const timestamps = cols.shift();
+        return { timestamps, series: cols };
+    }
+
+    function CsvFileDatasource(settings, updateCallback) {
+        let currentSettings = settings;
+        let filePath = currentSettings.filePath || null;
+
+        async function chooseFile() {
+            if (ipc) {
+                const chosen = await ipc.invoke('choose-csv-file');
+                if (chosen) {
+                    filePath = chosen;
+                    loadFile();
+                }
+            } else if (window.File && window.FileReader) {
+                const input = document.createElement('input');
+                input.type = 'file';
+                input.accept = '.csv';
+                await new Promise(resolve => {
+                    input.addEventListener('change', () => {
+                        const file = input.files[0];
+                        if (!file) { resolve(); return; }
+                        const reader = new FileReader();
+                        reader.onload = () => {
+                            const ds = parseCsv(reader.result, currentSettings.separator || ',', !!currentSettings.hasHeader);
+                            updateCallback(ds);
+                            resolve();
+                        };
+                        reader.readAsText(file);
+                    });
+                    input.click();
+                });
+                return;
+            }
+        }
+
+        function loadFile() {
+            if (!fs || !filePath) return;
+            try {
+                const data = fs.readFileSync(filePath, 'utf8');
+                const ds = parseCsv(data, currentSettings.separator || ',', !!currentSettings.hasHeader);
+                updateCallback(ds);
+            } catch (e) {
+                console.error('Failed to read CSV', e);
+            }
+        }
+
+        this.updateNow = async () => {
+            if (!filePath) await chooseFile();
+            loadFile();
+        };
+
+        this.onDispose = function () {};
+
+        this.onSettingsChanged = function (newSettings) {
+            currentSettings = newSettings;
+            filePath = currentSettings.filePath || filePath;
+            this.updateNow();
+        };
+
+        this.updateNow();
+    }
+
+    freeboard.loadDatasourcePlugin({
+        type_name: 'csv_file_datasource',
+        display_name: 'CSV File',
+        description: 'Load data from a CSV file and expose as dataset',
+        settings: [
+            { name: 'filePath', display_name: 'CSV File Path', type: 'text' },
+            { name: 'separator', display_name: 'Separator', type: 'text', default_value: ',' },
+            { name: 'hasHeader', display_name: 'First row is header', type: 'boolean', default_value: true }
+        ],
+        newInstance: function (settings, newInstanceCallback, updateCallback) {
+            newInstanceCallback(new CsvFileDatasource(settings, updateCallback));
+        }
+    });
+})();

--- a/main.js
+++ b/main.js
@@ -415,6 +415,18 @@ ipcMain.handle('choose-firmware-file', async () => {
     return filePaths[0];
 });
 
+// 📂 Open a dialog to choose a CSV data file
+ipcMain.handle('choose-csv-file', async () => {
+    const { canceled, filePaths } = await dialog.showOpenDialog(mainWindow, {
+        properties: ['openFile'],
+        filters: [{ name: 'CSV', extensions: ['csv'] }]
+    });
+    if (canceled || filePaths.length === 0) {
+        return null;
+    }
+    return filePaths[0];
+});
+
 // 🔥 Flash firmware to a board over serial
 ipcMain.handle('start-flash', async (event, { comPort, firmwarePath, mcumgrPath: userPath }) => {
     const existing = openPorts.get(comPort);


### PR DESCRIPTION
## Summary
- add a CSV file datasource plugin to allow plotting data from a CSV file
- load the new plugin in the dashboard
- let user choose the CSV file with a file explorer and drop refresh option

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_b_687e3956b6d88321becb8daf93702ec3